### PR TITLE
Fix: reversed markLabels closer to marks & added examples

### DIFF
--- a/examples/handle.js
+++ b/examples/handle.js
@@ -34,6 +34,10 @@ ReactDOM.render(
       <Slider min={0} max={20} defaultValue={3} handle={handle} />
     </div>
     <div style={wrapperStyle}>
+      <p>Reversed Slider with custom handle</p>
+      <Slider min={0} max={20} reverse defaultValue={3} handle={handle} />
+    </div>
+    <div style={wrapperStyle}>
       <p>Slider with fixed values</p>
       <Slider min={20} defaultValue={20} marks={{ 20: 20, 40: 40, 100: 100 }} step={null} />
     </div>

--- a/examples/marks.js
+++ b/examples/marks.js
@@ -29,6 +29,7 @@ ReactDOM.render(
       <p>Slider with marks, `step=null`</p>
       <Slider min={-10} marks={marks} step={null} onChange={log} defaultValue={20} />
     </div>
+
     <div style={style}>
       <p>Slider with marks and steps</p>
       <Slider dots min={-10} marks={marks} step={10} onChange={log} defaultValue={20} />

--- a/examples/marks.js
+++ b/examples/marks.js
@@ -33,6 +33,10 @@ ReactDOM.render(
       <p>Slider with marks and steps</p>
       <Slider dots min={-10} marks={marks} step={10} onChange={log} defaultValue={20} />
     </div>
+    <div style={style}>
+      <p>Reversed Slider with marks and steps</p>
+      <Slider dots reverse min={-10} marks={marks} step={10} onChange={log} defaultValue={20} />
+    </div>
 
     <div style={style}>
       <p>Slider with marks, `included=false`</p>

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -178,6 +178,23 @@ ReactDOM.render(
       />
     </div>
     <div style={style}>
+      <p>Reversed Slider with custom handle and track style.<strong>(The recommended new api)</strong></p>
+      <Slider
+        defaultValue={30}
+        trackStyle={{ backgroundColor: 'blue', height: 10 }}
+        reverse
+        handleStyle={{
+          borderColor: 'blue',
+          height: 28,
+          width: 28,
+          marginLeft: -14,
+          marginTop: -9,
+          backgroundColor: 'black',
+        }}
+        railStyle={{ backgroundColor: 'red', height: 10 }}
+      />
+    </div>
+    <div style={style}>
       <p>Basic Slider, disabled</p>
       <Slider onChange={log} disabled />
     </div>

--- a/src/common/Marks.jsx
+++ b/src/common/Marks.jsx
@@ -41,7 +41,9 @@ const Marks = ({
     const leftStyle = {
       transform: `translateX(-50%)`,
       msTransform: `translateX(-50%)`,
-      [reverse ? 'right' : 'left']: `${(point - min) / range * 100}%`,
+      [reverse ? 'right' : 'left']: reverse 
+        ? `${(point - (min / 4)) / range * 100}%`
+        : `${(point - min) / range * 100}%`,
     };
 
     const style = vertical ? bottomStyle : leftStyle;


### PR DESCRIPTION
You can see the examples at https://barakplasma.github.io/slider .
If you merge, I also recommend that you run `$ npm run gh-pages` in order to add a preview of the reversed component examples.